### PR TITLE
bump lwip to 0.0.9

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "gm": "^1.22.0",
     "image-size": "^0.5.0",
     "loader-utils": "^0.2.6",
-    "lwip": "0.0.8"
+    "lwip": "0.0.9"
   },
   "peerDependencies": {
     "gm": "*",


### PR DESCRIPTION
Bump lwip to 0.0.9 to enable install on node 6+. See https://github.com/EyalAr/lwip/pull/250
